### PR TITLE
NF: apache-fakegooglebot ignorecommand + DNSUtils.ipToName

### DIFF
--- a/config/filter.d/ignorecommands/apache-fakegooglebot
+++ b/config/filter.d/ignorecommands/apache-fakegooglebot
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# Inspired by https://isc.sans.edu/forums/diary/When+Google+isnt+Google/15968/
+#
+# Written in Python to reuse built-in Python batteries and not depend on
+# presence of host and cut commands
+#
+import sys
+
+def process_args(argv):
+    if len(argv) != 2:
+       sys.stderr.write("Please provide a single IP as an argument. Got: %s\n"
+                        % (argv[1:]))
+       sys.exit(2)
+
+    ip = argv[1]
+
+    from fail2ban.server.filter import DNSUtils
+    if not DNSUtils.isValidIP(ip):
+       sys.stderr.write("Argument must be a single valid IP. Got: %s\n"
+                        % ip)
+       sys.exit(3)
+    return ip
+
+def is_googlebot(ip):
+    import re
+    from fail2ban.server.filter import DNSUtils
+
+    host = DNSUtils.ipToName(ip)
+    sys.exit(0 if (host and re.match('crawl-.*\.googlebot\.com', host)) else 1)
+
+if __name__ == '__main__':
+    is_googlebot(process_args(sys.argv))

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -853,6 +853,14 @@ class DNSUtils:
 			return list()
 
 	@staticmethod
+	def ipToName(ip):
+		try:
+			return socket.gethostbyaddr(ip)[0]
+		except socket.error, e:
+			logSys.debug("Unable to find a name for the IP %s: %s" % (ip, e))
+			return None
+
+	@staticmethod
 	def searchIP(text):
 		""" Search if an IP address if directly available and return
 			it.


### PR DESCRIPTION
This way we would be more platform agnostic (e.g. host is not present on lean Debian installations I have just tried) and possibly come up with better unittest

Moreover -- I am thinking may be we should come up with a helper function to compare to any hostname pattern? ;)